### PR TITLE
securing-communication/drills: Fix wrong directory in solutions for i…

### DIFF
--- a/chapters/network-and-communication-security/securing-communication/drills/inspect-me-der/solution/solution.sh
+++ b/chapters/network-and-communication-security/securing-communication/drills/inspect-me-der/solution/solution.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-openssl x509 -noout -text -inform der -in ../public/example.der | grep -o 'SSS{.*}'
+openssl x509 -noout -text -inform der -in ../support/example.der | grep -o 'SSS{.*}'

--- a/chapters/network-and-communication-security/securing-communication/drills/inspect-me-pem/solution/solution.sh
+++ b/chapters/network-and-communication-security/securing-communication/drills/inspect-me-pem/solution/solution.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-openssl x509 -noout -text -in ../public/example.crt | grep -o 'SSS{.*}'
+openssl x509 -noout -text -in ../support/example.crt | grep -o 'SSS{.*}'


### PR DESCRIPTION
Fix inspect-me-pem & inspect-me-der solutions

Solutions were using the "public" directory, which doesn't exist.
This commit fixes this issue, by using the "support" directory.

