### PR TITLE
exotic-attacks: Add backup.zip for Handy Tool drill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.lib
 *.dll
 a.out
-# *.zip
+*.zip
 *.rar
 *gz
 *bz2

--- a/chapters/web-application-security/exotic-attacks/activities/handy-tool/deploy/Dockerfile
+++ b/chapters/web-application-security/exotic-attacks/activities/handy-tool/deploy/Dockerfile
@@ -1,5 +1,12 @@
-FROM php:7.2-apache
+FROM php:8.2-apache
+
+RUN apt-get update && apt-get install -y zip && rm -rf /var/lib/apt/lists/*
 
 COPY src/ /var/www/html/
+
+WORKDIR /var/www/html/
+
+RUN zip -r backup.zip index_to_zip.php
+RUN rm index_to_zip.php
 
 COPY flag /home/ctf/flag.txt

--- a/chapters/web-application-security/exotic-attacks/activities/handy-tool/src/index_to_zip.php
+++ b/chapters/web-application-security/exotic-attacks/activities/handy-tool/src/index_to_zip.php
@@ -1,0 +1,80 @@
+<?php
+class PHPClass {
+    public $condition;
+    public $prop;
+
+    function __construct() { }
+
+    function __wakeup() {
+        $forbbiden_commands = ["..."];
+
+        if (!isset($this->prop) or !isset($this->condition) or !$this->condition == true) {
+            return;
+        }
+
+        foreach ($forbbiden_commands as $cmd) {
+            if (strpos($this->prop, $cmd) !== false) {
+                return;
+            }
+        }
+
+        eval($this->prop);
+    }
+}
+?>
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+    </head>
+
+    <body>
+        <div>
+            <div class="container">
+                <div class="row">
+                    <div class="bg-white p-5 mx-auto col-md-8 col-10">
+                        <h3 class="display-3">Handy Tools<br></h3>
+                        <form method="GET">
+                            <div class="form-group">
+                                <label>Select tool</label>
+                                <select name="tool" class="form-control">
+                                    <option value="toupper">To Upper Case</option>
+                                    <option value="unserialize">Unserialize</option>
+                                    <option value="trim">Trim whitespaces</option>
+                                    <option value="manny">Guess my last name: Manny...</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label>Input</label>
+                                <input name="input" type="text" class="form-control">
+                                <small class="form-text text-muted"></small>
+                            </div>
+                            <?php
+                                if (isset($_GET['tool']) && $_GET['tool'] == 'toupper') {
+                                    echo var_dump(strtoupper($_GET['input']));
+                                    echo "<br>"; echo "<br>"; echo "<br>";
+                                } elseif (isset($_GET['tool']) && $_GET['tool'] == 'unserialize') {
+                                    echo var_dump(unserialize($_GET['input']));
+                                    echo "<br>"; echo "<br>"; echo "<br>";
+                                } elseif (isset($_GET['tool']) && $_GET['tool'] == 'trim') {
+                                    echo var_dump(str_replace(' ', '', $_GET['input']));
+                                    echo "<br>"; echo "<br>"; echo "<br>";
+                                } elseif (isset($_GET['tool']) && $_GET['tool'] == 'manny') {
+                                    if (strtolower($_GET['input']) == 'iscusitul')
+                                        echo "backup.zip";
+                                    else
+                                        echo "Wrong!";
+                                    echo "<br>"; echo "<br>"; echo "<br>";
+                                }
+                            ?>
+                            <input type="submit" class="btn btn-primary" name="submit" value="Submit" />
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
The Handy Tool drill requires students to download and analyze a 
backup.zip file containing the PHP source code. This archive is 
essential for understanding the PHPClass implementation and crafting 
the correct unserialization payload for the PHP Object Injection exploit.

Without this file, students cannot complete step 2 of the challenge 
(downloading /backup.zip), making the entire drill unsolvable.

* Added backup.zip containing index.php source code
* File is placed in src/ and copied to /var/www/html/ by Dockerfile
* Archive is required for students to analyze PHPClass for the exploit
* Tested locally with Docker: file accessible at /backup.zip

GitHub-Fixes: #86
Signed-off-by: Andreea Zdranc <andreeazdranc2@gmail.com>
